### PR TITLE
Swap comma and period

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ use { 'rareitems/put_at_end.nvim' }
   s("n", "<C-;>", m.put_semicolon)
   -- This keymap will put a semicolon at the end of the current line
 
-  s("n", "<C-,>", m.put_period) --This a period
-  s("n", "<C-.>", m.put_comma) --This a commna
+  s("n", "<C-.>", m.put_period) --This a period
+  s("n", "<C-,>", m.put_comma) --This a commna
   s("n", "<C-/>", m.put_questionmark) --This a question mark
   s("n", "<C-A>", function() m.put("STRING") end) --This 'STRING'
 ```

--- a/doc/put_at_end.txt
+++ b/doc/put_at_end.txt
@@ -12,12 +12,12 @@ put_at_end.put_semicolon()                            *put_at_end.put_semicolon*
 
 
 put_at_end.put_period()                                  *put_at_end.put_period*
-     Puts ',' at the end of the current line
+     Puts '.' at the end of the current line
      If the line has a comment it will be put before the comment.
 
 
 put_at_end.put_comma()                                    *put_at_end.put_comma*
-     Puts '.' at the end of the current line
+     Puts ',' at the end of the current line
      If the line has a comment it will be put before the comment.
 
 

--- a/lua/put_at_end/init.lua
+++ b/lua/put_at_end/init.lua
@@ -48,16 +48,16 @@ put_at_end.put_semicolon = function()
   f(";")
 end
 
---- Puts ',' at the end of the current line
---- If the line has a comment it will be put before the comment.
-put_at_end.put_period = function()
-  f(",")
-end
-
 --- Puts '.' at the end of the current line
 --- If the line has a comment it will be put before the comment.
-put_at_end.put_comma = function()
+put_at_end.put_period = function()
   f(".")
+end
+
+--- Puts ',' at the end of the current line
+--- If the line has a comment it will be put before the comment.
+put_at_end.put_comma = function()
+  f(",")
 end
 
 --- Puts '?' at the end of the current line


### PR DESCRIPTION
I noticed that `put_comma` would actually put a `.` instead of a `,`.
The same goes for `put_period` which would put a `,` instead of a `.`.
